### PR TITLE
chore: ensure macro is prepared for potential pretty printing improvements

### DIFF
--- a/pagetop-macros/src/lib.rs
+++ b/pagetop-macros/src/lib.rs
@@ -35,7 +35,13 @@ pub fn fn_builder(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let param: Vec<String> = args
         .iter()
-        .map(|arg| arg.split_whitespace().next().unwrap().to_string())
+        .map(|arg| {
+            arg.split_whitespace()
+                .next()
+                .unwrap()
+                .trim_end_matches(":")
+                .to_string()
+        })
         .collect();
 
     #[rustfmt::skip]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/117433#issuecomment-1793881869

I think this could be improved to split on `":"` instead and to `trim` the param to get rid of whitespace.
I'm not 100% confident that would work exactly as intended though, therefore this PR makes the minimal change.
